### PR TITLE
Ic role based authentication

### DIFF
--- a/src/aws/auth.controller.ts
+++ b/src/aws/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Headers , Body, UseGuards, Param} from '@nestjs/common';
+import { Controller, Get, Post, Headers , Body, UseGuards} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import {WriteEntryToTable, UserTimesheets} from '../dynamodb'; 
 

--- a/src/aws/auth.controller.ts
+++ b/src/aws/auth.controller.ts
@@ -24,7 +24,7 @@ export class AuthController {
   }
   
   @Get('timesheet')
-  @Roles('breaktime-admin')
+  //@Roles('breaktime-management-role')
   public async grab_timesheets(@Headers() headers: any): Promise<TimeSheetSchema[]> {
     const userId = await TokenClient.grabUserID(headers); 
 

--- a/src/aws/auth.controller.ts
+++ b/src/aws/auth.controller.ts
@@ -34,5 +34,5 @@ export class AuthController {
       return timesheets; 
     }
     return []; 
-  } 
+  }
 }

--- a/src/aws/auth.controller.ts
+++ b/src/aws/auth.controller.ts
@@ -1,11 +1,14 @@
-import { Controller, Get, Post, Headers , Body} from '@nestjs/common';
+import { Controller, Get, Post, Headers , Body, UseGuards} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import {WriteEntryToTable, UserTimesheets} from '../dynamodb'; 
 
 import TokenClient from './cognito/cognito.keyparser'
 import { TimeSheetSchema } from 'src/db/Timesheet';
+import { RolesGuard } from './guards/roles.guard';
+import { Roles } from './decorators/roles.decorators';
 
 @Controller('auth')
+@UseGuards(RolesGuard)
 export class AuthController {
   constructor(private authService: AuthService) {}
 
@@ -19,7 +22,9 @@ export class AuthController {
 
     return "Success!"  
   }
+  
   @Get('timesheet')
+  @Roles('breaktime-management-role')
   public async grab_timesheets(@Headers() headers: any): Promise<TimeSheetSchema[]> {
     const userId = await TokenClient.grabUserID(headers); 
 

--- a/src/aws/auth.controller.ts
+++ b/src/aws/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Headers , Body, UseGuards} from '@nestjs/common';
+import { Controller, Get, Post, Headers , Body, UseGuards, Param} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import {WriteEntryToTable, UserTimesheets} from '../dynamodb'; 
 
@@ -24,7 +24,7 @@ export class AuthController {
   }
   
   @Get('timesheet')
-  @Roles('breaktime-management-role')
+  @Roles('breaktime-admin')
   public async grab_timesheets(@Headers() headers: any): Promise<TimeSheetSchema[]> {
     const userId = await TokenClient.grabUserID(headers); 
 

--- a/src/aws/auth.service.ts
+++ b/src/aws/auth.service.ts
@@ -11,11 +11,9 @@ export class AuthService {
   async verifyJwt(jwt: string): Promise<AuthVerificationResponse> {
     try {
       const userPayload = await this.cognitoService.validate(jwt);
-      console.log(userPayload);
-      // TODO grab cognito groups from the user Payload, may want a secondary parent function that
-      // both authenticates the jwt and any user/group specifications
+      
+      // grab cognito groups from the user Payload to reutrn in the verification response.
       const groups = userPayload['cognito:groups'];
-      console.log(groups);
     
       return {isValidated: true, groups: groups}; 
     } catch (e) {

--- a/src/aws/auth.service.ts
+++ b/src/aws/auth.service.ts
@@ -8,7 +8,7 @@ export class AuthService {
     private cognitoService: CognitoService,
   ) {}
 
-  async verifyJwt(jwt: string): Promise<Boolean> {
+  async verifyJwt(jwt: string): Promise<AuthVerificationResponse> {
     try {
       const userPayload = await this.cognitoService.validate(jwt);
       console.log(userPayload);
@@ -17,9 +17,11 @@ export class AuthService {
       const groups = userPayload['cognito:groups'];
       console.log(groups);
     
-      return true; 
+      return {isValidated: true, groups: groups}; 
     } catch (e) {
       throw new UnauthorizedException();
     }
   }
 }
+
+export type AuthVerificationResponse = { isValidated: boolean, groups: string[] }

--- a/src/aws/auth.service.ts
+++ b/src/aws/auth.service.ts
@@ -11,6 +11,11 @@ export class AuthService {
   async verifyJwt(jwt: string): Promise<Boolean> {
     try {
       const userPayload = await this.cognitoService.validate(jwt);
+      console.log(userPayload);
+      // TODO grab cognito groups from the user Payload, may want a secondary parent function that
+      // both authenticates the jwt and any user/group specifications
+      const groups = userPayload['cognito:groups'];
+      console.log(groups);
     
       return true; 
     } catch (e) {

--- a/src/aws/auth.service.ts
+++ b/src/aws/auth.service.ts
@@ -8,11 +8,17 @@ export class AuthService {
     private cognitoService: CognitoService,
   ) {}
 
+  /**
+   * 
+   * @param jwt The access token to be validated
+   * @returns if the validation was successful and what Cognito groups the user is a part of
+   */
   async verifyJwt(jwt: string): Promise<AuthVerificationResponse> {
     try {
       const userPayload = await this.cognitoService.validate(jwt);
       
       // grab cognito groups from the user Payload to reutrn in the verification response.
+      // This is so that the role-based access is determined by Cognito groups
       const groups = userPayload['cognito:groups'];
     
       return {isValidated: true, groups: groups}; 

--- a/src/aws/cognito/cognito.wrapper.ts
+++ b/src/aws/cognito/cognito.wrapper.ts
@@ -19,7 +19,6 @@ export class CognitoWrapper {
   async validate(jwt: string) {
     try {
       const payload = await this.verifier.verify(jwt); 
-      console.log(payload);
       return payload 
     } catch (error){
       console.log(error); 

--- a/src/aws/cognito/cognito.wrapper.ts
+++ b/src/aws/cognito/cognito.wrapper.ts
@@ -19,6 +19,7 @@ export class CognitoWrapper {
   async validate(jwt: string) {
     try {
       const payload = await this.verifier.verify(jwt); 
+      console.log(payload);
       return payload 
     } catch (error){
       console.log(error); 

--- a/src/aws/decorators/roles.decorators.ts
+++ b/src/aws/decorators/roles.decorators.ts
@@ -1,0 +1,3 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);

--- a/src/aws/decorators/roles.decorators.ts
+++ b/src/aws/decorators/roles.decorators.ts
@@ -1,3 +1,6 @@
 import { SetMetadata } from '@nestjs/common';
 
+/**
+ * A custom decorator that allows us to take in a set of groups or roles and process them in the Nest pipeline (i.e. RolesGuard).
+ */
 export const Roles = (...roles: string[]) => SetMetadata('roles', roles);

--- a/src/aws/guards/roles.guard.ts
+++ b/src/aws/guards/roles.guard.ts
@@ -1,13 +1,24 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
-import { Observable } from 'rxjs';
+import { Reflector } from '@nestjs/core';
 
 
 // TODO : currently allows all roles to access
 @Injectable()
 export class RolesGuard implements CanActivate {
-  canActivate(
-    context: ExecutionContext,
-  ): boolean | Promise<boolean> | Observable<boolean> {
-    return true;
-  }
+    constructor(private reflector: Reflector) {}
+
+    canActivate(context: ExecutionContext): boolean {
+      const roles = this.reflector.get<string[]>('roles', context.getHandler());
+      /*if (!roles) {
+        return true;
+      }*/
+
+      const request = context.switchToHttp().getRequest();
+      const user = request.user;
+      console.log(user);
+      if (user.groups.length != 0) {
+        return true;
+      }
+      return false; // TODO : will need to match roles
+    }
 }

--- a/src/aws/guards/roles.guard.ts
+++ b/src/aws/guards/roles.guard.ts
@@ -1,24 +1,39 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { AuthVerificationResponse } from '../auth.service';
 
 
-// TODO : currently allows all roles to access
+/**
+ * Nest guard for role-based access. Reference: https://docs.nestjs.com/guards
+ */
 @Injectable()
 export class RolesGuard implements CanActivate {
     constructor(private reflector: Reflector) {}
 
+    /**
+     * Determines if a given request can be executed based on the role's of the requesting user.
+     * @param context the execution context passed from the previous step in the pipeline. 
+     * Should contain the request and user payload from AuthService. For more information, see https://docs.nestjs.com/fundamentals/execution-context
+     * @returns if the endpoint can be run for the given user.
+     */
     canActivate(context: ExecutionContext): boolean {
-      const roles = this.reflector.get<string[]>('roles', context.getHandler());
-      /*if (!roles) {
-        return true;
-      }*/
+      // Get the roles defined for the endpoint that are allowed to access it.
+      const allowedRoles = this.reflector.get<string[]>('roles', context.getHandler());
 
-      const request = context.switchToHttp().getRequest();
-      const user = request.user;
-      console.log(user);
-      if (user.groups.length != 0) {
+      // If there are no specified roles for the endpoint, allow any user to access.
+      if (!allowedRoles) {
         return true;
       }
-      return false; // TODO : will need to match roles
+
+      // Get the request from the last-run step of the pipeline (in this case, the AuthMiddleware) and pull the necessary user data
+      // that has been set. Keep in mind, this is not necessarily the actual user payload or JWT from the original request. Instead,
+      // this is what has been set by the previous step(s).
+      const request = context.switchToHttp().getRequest();
+      const user: AuthVerificationResponse = request.user;
+
+      // Check that the user belongs to at least one of the required roles
+      const validUserGroups = user.groups.filter(group => allowedRoles.includes(group));
+      console.log(validUserGroups);
+      return validUserGroups.length > 0;
     }
 }

--- a/src/aws/guards/roles.guard.ts
+++ b/src/aws/guards/roles.guard.ts
@@ -1,0 +1,13 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+
+// TODO : currently allows all roles to access
+@Injectable()
+export class RolesGuard implements CanActivate {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    return true;
+  }
+}

--- a/src/aws/guards/roles.guard.ts
+++ b/src/aws/guards/roles.guard.ts
@@ -4,14 +4,14 @@ import { AuthVerificationResponse } from '../auth.service';
 
 
 /**
- * Nest guard for role-based access. Reference: https://docs.nestjs.com/guards
+ * Nest guard for role-based access (i.e. groups from Cognito). Reference: https://docs.nestjs.com/guards
  */
 @Injectable()
 export class RolesGuard implements CanActivate {
     constructor(private reflector: Reflector) {}
 
     /**
-     * Determines if a given request can be executed based on the role's of the requesting user.
+     * Determines if a given request can be executed based on the roles of the requesting user.
      * @param context the execution context passed from the previous step in the pipeline. 
      * Should contain the request and user payload from AuthService. For more information, see https://docs.nestjs.com/fundamentals/execution-context
      * @returns if the endpoint can be run for the given user.
@@ -28,11 +28,14 @@ export class RolesGuard implements CanActivate {
       // Get the request from the last-run step of the pipeline (in this case, the AuthMiddleware) and pull the necessary user data
       // that has been set. Keep in mind, this is not necessarily the actual user payload or JWT from the original request. Instead,
       // this is what has been set by the previous step(s).
+      // In our case, this is from the Cognito groups a user is assigned.
       const request = context.switchToHttp().getRequest();
       const user: AuthVerificationResponse = request.user;
 
       // Check that the user belongs to at least one of the required roles
       const validUserGroups = user.groups.filter(group => allowedRoles.includes(group));
+
+      // For testing purposes, print out the groups a user is a part of that are allowed to access this resource
       console.log(validUserGroups);
       return validUserGroups.length > 0;
     }

--- a/src/aws/middleware/authentication.middleware.ts
+++ b/src/aws/middleware/authentication.middleware.ts
@@ -11,7 +11,8 @@ export class AuthenticationMiddleware implements NestMiddleware {
   constructor(private authService: AuthService) {}
 
   async use(req: any, res: any, next: () => void) {
-    console.log("Authentication middleware.ts callback is here"); 
+    console.log("Authentication middleware.ts callback is here");
+    console.log()
     
     const authHeader = req.headers['authorization'];
     if (!authHeader) return next();
@@ -19,7 +20,10 @@ export class AuthenticationMiddleware implements NestMiddleware {
     const token = authHeader.split(' ')[1]; // get part of string after space
     if (!token) return next();
     try {
+      // This will be a AuthVerificationResponse object that contains the group data of a user
       const user = await this.authService.verifyJwt(token);
+
+      // Set the user of the Nest request so that the next step in the pipeline (RolesGuard) can access it
       req.user = user;
     } catch (e) {
       this.logger.error(e);

--- a/src/aws/middleware/authentication.middleware.ts
+++ b/src/aws/middleware/authentication.middleware.ts
@@ -11,9 +11,6 @@ export class AuthenticationMiddleware implements NestMiddleware {
   constructor(private authService: AuthService) {}
 
   async use(req: any, res: any, next: () => void) {
-    console.log("Authentication middleware.ts callback is here");
-    console.log()
-    
     const authHeader = req.headers['authorization'];
     if (!authHeader) return next();
     


### PR DESCRIPTION
ℹ️ Issue #14 

📝 Description:

Added in functionality for role/group-based access to the backend routes using a RolesGuard. This allows us to use the custom '@Roles' decorator to define which cognito groups are allowed to access certain routes.

✔️ Testing 

- Uncomment out the '@Roles' decorator in `auth.controller.ts` to test for different roles.
- Run front and backend. Login to the timesheets page with an account that doesn't have the roles needed to access (as specified when you uncommented the line)

When a user **not** authorized for the endpoint tries to access, you should see the following error in the frontend:

![FE-image for when roles don't match](https://user-images.githubusercontent.com/32255130/232339310-d8810b73-2003-4c53-80e2-d01511a319d9.JPG)

When a user **is** authorized for an endpoint (or there are no roles specified for the RolesGuard), any relevant timesheet data should pop-up on the local front-end app, and the following message should be logged in the backend console:

_First line: the valid roles, if any are needed, that the user has for this endpoint_
_Second line: console message printed when the call to database is being run_

![BE valid roles](https://user-images.githubusercontent.com/32255130/232339473-12d27fb0-5821-4e1c-bbee-a813deafc30d.JPG)

🏕️ (Optional) Future Work / Notes

Ideally, we'll have unit tests for the functionality of the RolesGuard in the future, rather than just manual testing.

Also, whenever we need to implement screens for the admin-only pages on the front, we'll want to work some error handling and 403 screens into the UI instead of just seeing the error in console.