### PR TITLE
Ic updating schema

### DIFF
--- a/src/aws/auth.controller.ts
+++ b/src/aws/auth.controller.ts
@@ -26,6 +26,7 @@ export class AuthController {
     if (userId) {
       console.log("Fetching timesheets for user ", userId); 
       const timesheets = await UserTimesheets(userId)
+      console.log(timesheets);
       return timesheets; 
     }
     return []; 

--- a/src/db/Timesheet.ts
+++ b/src/db/Timesheet.ts
@@ -1,12 +1,54 @@
 import { z } from "zod";
 
+/**
+ * Represents the database schema for a comment
+ */
+export const CommentSchema = z.object({
+  Type: z.string(),
+  AuthorUUID: z.string(),
+  Timestamp: z.number(),
+  Content: z.string(),
+  State: z.string(),
+})
+
+/**
+ * Represents the database schema for a schedule shift entry, made by a supervisor or admin
+ */
+export const ScheduleEntrySchema = z.object({
+  StartDate: z.number(),
+  EndDate: z.number(),
+})
+
+/**
+ * Represents the database schema for a clockin/clockout pair in epoch
+ */
+export const TimeEntrySchema = z.object({
+  StartDate: z.number(),
+  EndDate: z.number(),
+})
+
+/**
+ * Represents the database schema for a single shift or entry in the weekly timesheet
+ */
+export const TimesheetEntrySchema = z.object({
+  Type: z.string(), 
+  AssociateTimes: TimeEntrySchema,
+  SupervisorTimes: TimeEntrySchema.optional(),
+  AdminTimes: TimeEntrySchema.optional(),
+  Comment: CommentSchema.optional(),
+})
+
+/**
+ * Represents the database schema for a weekly timesheet
+ */
 export const TimeSheetSchema = z.object({
   TimesheetID: z.number(), 
   UserID: z.string(), 
   StartDate: z.number(),
   Status: z.string(),
-  Company: z.string(), 
-  TableData: z.array(z.any()), 
+  CompanyID: z.string(), 
+  TableData: z.array(TimeEntrySchema), 
+  ScheduleData: z.array(ScheduleEntrySchema).optional(),
 })
 
 export type TimeSheetSchema = z.infer<typeof TimeSheetSchema>

--- a/src/db/Timesheet.ts
+++ b/src/db/Timesheet.ts
@@ -17,16 +17,16 @@ export const NoteSchema = z.object({
  * Represents the database schema for a schedule shift entry, made by a supervisor or admin
  */
 export const ScheduleEntrySchema = z.object({
-  StartDate: z.number(),
-  EndDate: z.number(),
+  StartDateTime: z.number(),
+  EndDateTime: z.number(),
 })
 
 /**
  * Represents the database schema for a clockin/clockout pair in epoch
  */
 export const TimeEntrySchema = z.object({
-  StartDate: z.number(),
-  EndDate: z.number(),
+  StartDateTime: z.number(),
+  EndDateTime: z.number(),
 })
 
 /**
@@ -40,7 +40,7 @@ export const TimeEntrySchema = z.object({
  */
 export const StatusSchema = z.object({
   StatusType: z.enum(["HoursSubmitted", "HoursReviewed", "ScheduleSubmitted", "Finalized"]),
-  SubmittedDate: z.number(),
+  SubmittedDateTime: z.number(),
 })
 
 /**

--- a/src/db/Timesheet.ts
+++ b/src/db/Timesheet.ts
@@ -6,11 +6,11 @@ import { z } from "zod";
  * -- Report: a specific report to reflect an incident that happens and requires admin attention, e.g. no-show or late attendance
  */
 export const NoteSchema = z.object({
-  Type: z.string(),
-  AuthorUUID: z.string(),
+  Type: z.enum(["Comment", "Report"]),
+  AuthorUUID: z.string().uuid(),
   DateTime: z.number(),
   Content: z.string(),
-  State: z.string(),
+  State: z.enum(["Active", "Deleted"]),
 })
 
 /**
@@ -31,16 +31,15 @@ export const TimeEntrySchema = z.object({
 
 /**
  * Represents the database schema for the status of a timesheet. This could be one of the following types:
- * -- NotSubmitted
- * -- SupervisorReview (associate submitted, waiting for supervisor to submit)
- * -- AdminReview (assosciate and supervisor have both submitted, waiting for admin to submit)
- * -- Approved (Breaktime admin has reviewed and approved the associate and supervisor submissions)
- * -- NotApproved (Timesheet could not be process for some reason, further manual action is required)
+ * -- HoursSubmitted (Associate has submitted their hours worked)
+ * -- HoursReviewed (Supervisor has reviewed and approved the associate-submitted hours)
+ * -- ScheduleSubmitted (Supervisor has submitted the scheduled hours)
+ * -- Finalized (Admin has approved the submitted hours and schedule, and resolved any issue necessary)
  * 
  * SubmittedDate reflects the time of last submission, whether from associate, supervisor, or admin.
  */
 export const StatusSchema = z.object({
-  StatusType: z.string(),
+  StatusType: z.enum(["HoursSubmitted", "HoursReviewed", "ScheduleSubmitted", "Finalized"]),
   SubmittedDate: z.number(),
 })
 
@@ -59,13 +58,13 @@ export const TimesheetEntrySchema = z.object({
  */
 export const TimeSheetSchema = z.object({
   TimesheetID: z.number(), 
-  UserID: z.string(), 
+  UserID: z.string().uuid(), 
   StartDate: z.number(),
-  Status: StatusSchema,
+  Status: z.array(StatusSchema),
   CompanyID: z.string(), 
-  HoursData: z.array(TimesheetEntrySchema), 
-  ScheduleData: z.array(ScheduleEntrySchema).optional(),
-  WeekNotes: z.array(NoteSchema).optional(),
+  HoursData: z.array(TimesheetEntrySchema).default([]), 
+  ScheduleData: z.array(ScheduleEntrySchema).default([]),
+  WeekNotes: z.array(NoteSchema).default([]),
 })
 
 export type TimeSheetSchema = z.infer<typeof TimeSheetSchema>

--- a/src/db/Timesheet.ts
+++ b/src/db/Timesheet.ts
@@ -60,7 +60,7 @@ export const TimeSheetSchema = z.object({
   TimesheetID: z.number(), 
   UserID: z.string().uuid(), 
   StartDate: z.number(),
-  Status: z.array(StatusSchema),
+  StatusList: z.array(StatusSchema),
   CompanyID: z.string(), 
   HoursData: z.array(TimesheetEntrySchema).default([]), 
   ScheduleData: z.array(ScheduleEntrySchema).default([]),

--- a/src/db/Timesheet.ts
+++ b/src/db/Timesheet.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
 /**
- * Represents the database schema for a comment
+ * Represents the database schema for a note. This can be one of the following types:
+ * -- Comment: a general comment made for an entry or whole timesheet.
+ * -- Report: a specific report to reflect an incident that happens and requires admin attention, e.g. no-show or late attendance
  */
-export const CommentSchema = z.object({
+export const NoteSchema = z.object({
   Type: z.string(),
   AuthorUUID: z.string(),
-  Timestamp: z.number(),
+  DateTime: z.number(),
   Content: z.string(),
   State: z.string(),
 })
@@ -27,19 +29,29 @@ export const TimeEntrySchema = z.object({
   EndDate: z.number(),
 })
 
+/**
+ * Represents the database schema for the status of a timesheet. This could be one of the following types:
+ * -- NotSubmitted
+ * -- SupervisorReview (associate submitted, waiting for supervisor to submit)
+ * -- AdminReview (assosciate and supervisor have both submitted, waiting for admin to submit)
+ * -- Approved (Breaktime admin has reviewed and approved the associate and supervisor submissions)
+ * -- NotApproved (Timesheet could not be process for some reason, further manual action is required)
+ * 
+ * SubmittedDate reflects the time of last submission, whether from associate, supervisor, or admin.
+ */
 export const StatusSchema = z.object({
   StatusType: z.string(),
   SubmittedDate: z.number(),
 })
 
 /**
- * Represents the database schema for a single shift or entry in the weekly timesheet
+ * Represents the database schema for a single shift or entry in the weekly timesheet. 
  */
 export const TimesheetEntrySchema = z.object({
-  AssociateTimes: TimeEntrySchema.optional(), // TODO should this be optional, since it's possible for a supervisor to report a schedule entry the associate didn't log?
+  AssociateTimes: TimeEntrySchema.optional(),
   SupervisorTimes: TimeEntrySchema.optional(),
   AdminTimes: TimeEntrySchema.optional(),
-  Comment: CommentSchema.optional(),
+  Note: NoteSchema.optional(),
 })
 
 /**
@@ -51,9 +63,9 @@ export const TimeSheetSchema = z.object({
   StartDate: z.number(),
   Status: StatusSchema,
   CompanyID: z.string(), 
-  TableData: z.array(TimesheetEntrySchema), 
+  HoursData: z.array(TimesheetEntrySchema), 
   ScheduleData: z.array(ScheduleEntrySchema).optional(),
-  WeekComments:z.array(CommentSchema).optional(),
+  WeekNotes: z.array(NoteSchema).optional(),
 })
 
 export type TimeSheetSchema = z.infer<typeof TimeSheetSchema>

--- a/src/db/Timesheet.ts
+++ b/src/db/Timesheet.ts
@@ -27,12 +27,13 @@ export const TimeEntrySchema = z.object({
   EndDate: z.number(),
 })
 
+// TODO : make sure this works with the JSON documents in dynamo - might be a string that needs to be parsed to JSON
 /**
  * Represents the database schema for a single shift or entry in the weekly timesheet
  */
 export const TimesheetEntrySchema = z.object({
   Type: z.string(), 
-  AssociateTimes: TimeEntrySchema,
+  AssociateTimes: TimeEntrySchema.optional(), // TODO should this be optional, since it's possible for a supervisor to report a schedule entry the associate didn't log?
   SupervisorTimes: TimeEntrySchema.optional(),
   AdminTimes: TimeEntrySchema.optional(),
   Comment: CommentSchema.optional(),
@@ -47,7 +48,7 @@ export const TimeSheetSchema = z.object({
   StartDate: z.number(),
   Status: z.string(),
   CompanyID: z.string(), 
-  TableData: z.array(TimeEntrySchema), 
+  TableData: z.array(TimesheetEntrySchema), 
   ScheduleData: z.array(ScheduleEntrySchema).optional(),
 })
 

--- a/src/db/Timesheet.ts
+++ b/src/db/Timesheet.ts
@@ -27,12 +27,15 @@ export const TimeEntrySchema = z.object({
   EndDate: z.number(),
 })
 
-// TODO : make sure this works with the JSON documents in dynamo - might be a string that needs to be parsed to JSON
+export const StatusSchema = z.object({
+  StatusType: z.string(),
+  SubmittedDate: z.number(),
+})
+
 /**
  * Represents the database schema for a single shift or entry in the weekly timesheet
  */
 export const TimesheetEntrySchema = z.object({
-  Type: z.string(), 
   AssociateTimes: TimeEntrySchema.optional(), // TODO should this be optional, since it's possible for a supervisor to report a schedule entry the associate didn't log?
   SupervisorTimes: TimeEntrySchema.optional(),
   AdminTimes: TimeEntrySchema.optional(),
@@ -46,10 +49,11 @@ export const TimeSheetSchema = z.object({
   TimesheetID: z.number(), 
   UserID: z.string(), 
   StartDate: z.number(),
-  Status: z.string(),
+  Status: StatusSchema,
   CompanyID: z.string(), 
   TableData: z.array(TimesheetEntrySchema), 
   ScheduleData: z.array(ScheduleEntrySchema).optional(),
+  WeekComments:z.array(CommentSchema).optional(),
 })
 
 export type TimeSheetSchema = z.infer<typeof TimeSheetSchema>

--- a/src/dynamodb.ts
+++ b/src/dynamodb.ts
@@ -18,12 +18,14 @@ console.log('secret', process.env.AWS_SECRET_ACCESS_KEY!);
 const client = new DynamoDB({ region: 'us-east-2' });
 
 export async function UserTimesheets(uuid:string): Promise<TimeSheetSchema[]> {
+  // Set up the query to get all timesheets for a given uuid
   const command = new QueryCommand({
     TableName: 'BreaktimeTimesheets',
     KeyConditionExpression: "UserID = :s", 
     ExpressionAttributeValues: {
       ":s": { S: `${uuid}` }}, 
   });
+
   const dynamoRawResult = await client.send(command);
 
   if (dynamoRawResult == null || dynamoRawResult.Items == null) {

--- a/src/dynamodb.ts
+++ b/src/dynamodb.ts
@@ -36,7 +36,6 @@ export async function UserTimesheets(uuid:string): Promise<TimeSheetSchema[]> {
    TimeSheetSchema.parse(i)
   );
 
-  console.log(timesheetData);
   return timesheetData;
 }
 

--- a/src/dynamodb.ts
+++ b/src/dynamodb.ts
@@ -35,6 +35,8 @@ export async function UserTimesheets(uuid:string): Promise<TimeSheetSchema[]> {
   const timesheetData = unmarshalledItems.map((i) =>
    TimeSheetSchema.parse(i)
   );
+
+  console.log(timesheetData);
   return timesheetData;
 }
 


### PR DESCRIPTION
ℹ️ Issue #15 and Issue #21 

📝 Description

Updated the expected schema for timesheet items read in from the database according to discussed changes. [Schema diagram](https://lucid.app/lucidchart/912e6933-6883-4402-b926-805c934ded0c/edit?viewport_loc=-32%2C-331%2C1286%2C1564%2C0_0&invitationId=inv_4b8281c9-b632-4438-9daa-06e3716331c5)

✔️ Testing 

Testing via console log, frontend with an updated DynamoDB entry.

To replicate: 

- Find the userID for your test Breaktime account (AWS Console -> UserPool -> Breaktime -> Select your user)
- Duplicate this item and edit as need (but keep the general structure) from DynamoDB, making sure to change the UserID to your account's ID:

![image](https://user-images.githubusercontent.com/32255130/233478482-a2671e24-db4f-4453-82fb-3dcbde200a99.png)

- Run the backend and frontend locally. Navigate to the timesheets page on the frontend. Upon loading, you should see the correct entries show up on the frontend.

You should also see the list of timesheets printed in the backend console:

`[
  {
    TimesheetID: 11111,
    UserID: 'd396491c-22cf-4d63-af1e-4e70e95a29c7',
    StartDate: 1681012800,
    Status: { StatusType: 'Submitted', SubmittedDate: 1681617600 },
    CompanyID: 'Mcdonalds',
    TableData: [ [Object] ]
  }
]`

🏕️ (Optional) Future Work / Notes 

Get automated tests set up, maybe look into DynamoDB local for local ITs?