### PR TITLE
Adjustments to TimesheetEntrySchema for new CellType enum to work

### DIFF
--- a/src/db/frontend/CellTypes.ts
+++ b/src/db/frontend/CellTypes.ts
@@ -4,7 +4,7 @@
 
 
 export enum CellType {
-    Regular = "Regular", 
+    Regular = "Time Worked", 
     PTO = "PTO"
 }; 
 

--- a/src/db/schemas/Timesheet.ts
+++ b/src/db/schemas/Timesheet.ts
@@ -40,7 +40,8 @@ export const TimeEntrySchema = z.object({
     @PTO - Cell signifying paid time off (PTO) 
 */
 export enum CellType {
-  REGULAR = "Regular", 
+  REGULAR_LEGACY = "Regular", // No longer using this format for data, but some older timesheet entries may have the 'legacy' type
+  REGULAR = "Time Worked",
   PTO = "PTO"
 }
 
@@ -48,7 +49,7 @@ export enum CellType {
  * Represents the database schema for a single shift or entry in the weekly timesheet. 
  */
 export const TimesheetEntrySchema = z.object({
-  Type: z.enum([CellType.REGULAR, CellType.PTO]),
+  Type: z.enum([CellType.REGULAR, CellType.REGULAR_LEGACY, CellType.PTO]).transform((cellType) => cellType === CellType.REGULAR_LEGACY ? CellType.REGULAR : cellType),
   EntryID: z.string(), 
   Date: z.number(), 
   AssociateTimes: TimeEntrySchema.optional(),


### PR DESCRIPTION
ℹ️ Issue Closes #60 on frontend (backend changes were also necessary to maintain backwards compatibility)

📝 Description
Small change to allow for the new CellType value 'Time Worked' to be saved to the backend, and still be able to read in and update any old values of 'Regular' for the frontend.

✔️ Testing What steps did you take to verify your changes work? 

Run the frontend and backend together and made sure there were no errors. Checked Dynamo to ensure that any new Timesheets had the correct 'Time Worked'.

