### PR TITLE
61 timesheet submit button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,10 @@
         "dotenv": "^16.0.3",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.43",
+        "nest": "^0.1.6",
+        "nest.js": "^1.0.8",
+        "nestjs": "^0.0.1",
+        "node.js": "^0.0.1-security",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0",
         "zod": "^3.21.4"
@@ -7136,6 +7140,24 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/nest": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/nest/-/nest-0.1.6.tgz",
+      "integrity": "sha512-21378J/6pHB9EZMId5yz9DaxVj778pCHhzfXhRLLrLWZydpLgbsyxL5B5QyTSWJBk5L8XbiGgMvNZMb/qBySYg==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nest.js": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/nest.js/-/nest.js-1.0.8.tgz",
+      "integrity": "sha512-dVoDeG+Om5IauH4FnjBPgrIsfrZiY2upAWO5EZgpLhIVELfBe4rIvnDpUXBM+LvD5DUZUZnCHKsHgQ05PIkwzA=="
+    },
+    "node_modules/nestjs": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/nestjs/-/nestjs-0.0.1.tgz",
+      "integrity": "sha512-LJTf2zDRtWE69B6R2DUW6/LCftgVOq3kp3aqxPsB0eei8OX+lW2RFjzREZWRL1GUD/jGdBSMhM3Q5YWLC2uHNg=="
+    },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
@@ -7181,6 +7203,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
       "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==",
       "dev": true
+    },
+    "node_modules/node.js": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/node.js/-/node.js-0.0.1-security.tgz",
+      "integrity": "sha512-8tWQiyg/3ggdLTrtfgj/NxmZpC20eB1U5VNkqt2dbelpcr3NrfjpEE3DgifpBOCJ4Xu9Obvu8iju63ViQW3Hvg=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "dotenv": "^16.0.3",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.43",
+    "nest": "^0.1.6",
+    "nest.js": "^1.0.8",
+    "nestjs": "^0.0.1",
+    "node.js": "^0.0.1-security",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
     "zod": "^3.21.4"

--- a/src/aws/auth.controller.ts
+++ b/src/aws/auth.controller.ts
@@ -38,6 +38,7 @@ export class AuthController {
       return "Success"; 
     }
   }
+  
   @Get("timesheet")
   //@Roles('breaktime-management-role')
   

--- a/src/aws/auth.controller.ts
+++ b/src/aws/auth.controller.ts
@@ -32,10 +32,12 @@ export class AuthController {
   ): Promise<string> {
     const userId = await TokenClient.grabUserID(headers); 
     if (userId) {
-      console.log("Writing")
+      console.log("Update Timesheet Request: Processing")
+      console.log("Request received:")
+      console.log(body)
       const result = this.uploadApi.updateTimesheet(body, userId); 
-      //Do something with this result? 
-      return "Success"; 
+      //TODO: Do something with this result? 
+      return result; 
     }
   }
   

--- a/src/aws/cognito/cognito.keyparser.ts
+++ b/src/aws/cognito/cognito.keyparser.ts
@@ -12,9 +12,10 @@ export class JWTVerifier {
   public async grabUserID(headers: any): Promise<string> {
     if (process.env.ENV_TYPE && process.env.ENV_TYPE === "test") {
       console.log(
-        "Testing environment - mock user sub will be used with token client"
+        "Testing environment - mock user sub will be used with token client: ",
+        process.env.MOCK_USER_SUB
       );
-      return mockSupervisor.sub;
+      return process.env.MOCK_USER_SUB;
     }
 
     if (headers.hasOwnProperty("authorization")) {

--- a/src/db/Timesheet.ts
+++ b/src/db/Timesheet.ts
@@ -42,7 +42,6 @@ export const StatusSchema = z.object({
   StatusType: z.enum([
     "HoursSubmitted",
     "HoursReviewed",
-    "ScheduleSubmitted",
     "Finalized",
   ]),
   SubmittedDateTime: z.number(),
@@ -65,7 +64,7 @@ export const TimeSheetSchema = z.object({
   TimesheetID: z.number(),
   UserID: z.string().uuid(),
   StartDate: z.number(),
-  StatusList: z.array(StatusSchema),
+  StatusList: z.array(StatusSchema), // TODO: This is no longer correct schema for the database. This should be it's own object
   CompanyID: z.string(),
   HoursData: z.array(TimesheetEntrySchema).default([]),
   ScheduleData: z.array(ScheduleEntrySchema).default([]),
@@ -73,3 +72,9 @@ export const TimeSheetSchema = z.object({
 });
 
 export type TimeSheetSchema = z.infer<typeof TimeSheetSchema>;
+
+export enum TimesheetStatus {
+  HOURS_SUBMITTED="HoursSubmitted",
+  HOURS_REVIEWED="HoursReviewed",
+  FINALIZED="Finalized"
+}

--- a/src/db/frontend/CellTypes.ts
+++ b/src/db/frontend/CellTypes.ts
@@ -4,7 +4,7 @@
 
 
 export enum CellType {
-    Regular = "Regular", 
+    Regular = "Time Worked", 
     PTO = "PTO"
 }; 
 

--- a/src/db/frontend/TimesheetSchema.ts
+++ b/src/db/frontend/TimesheetSchema.ts
@@ -14,7 +14,7 @@ export const StatusEntryType = z.union(
   }), 
   z.undefined()]); 
 
-// Status type contains the four stages of the pipeline we have defined 
+// Status type contains the three stages of the pipeline we have defined 
 export const StatusType = z.object({
   HoursSubmitted: StatusEntryType, 
   HoursReviewed: StatusEntryType,

--- a/src/db/frontend/TimesheetSchema.ts
+++ b/src/db/frontend/TimesheetSchema.ts
@@ -18,7 +18,6 @@ export const StatusEntryType = z.union(
 export const StatusType = z.object({
   HoursSubmitted: StatusEntryType, 
   HoursReviewed: StatusEntryType,
-  ScheduleSubmitted: StatusEntryType, 
   Finalized: StatusEntryType 
 });
 export type StatusType = z.infer<typeof StatusType> 

--- a/src/db/schemas/Timesheet.ts
+++ b/src/db/schemas/Timesheet.ts
@@ -72,7 +72,6 @@ export const StatusEntryType = z.union(
 export const TimesheetStatus = z.object({
   HoursSubmitted: StatusEntryType, 
   HoursReviewed: StatusEntryType,
-  ScheduleSubmitted: StatusEntryType, 
   Finalized: StatusEntryType 
 });
 

--- a/src/db/schemas/Timesheet.ts
+++ b/src/db/schemas/Timesheet.ts
@@ -40,7 +40,8 @@ export const TimeEntrySchema = z.object({
     @PTO - Cell signifying paid time off (PTO) 
 */
 export enum CellType {
-  REGULAR = "Regular", 
+  REGULAR_LEGACY = "Regular", // No longer using this format for data, but some older timesheet entries may have the 'legacy' type
+  REGULAR = "Time Worked",
   PTO = "PTO"
 }
 
@@ -48,7 +49,7 @@ export enum CellType {
  * Represents the database schema for a single shift or entry in the weekly timesheet. 
  */
 export const TimesheetEntrySchema = z.object({
-  Type: z.enum([CellType.REGULAR, CellType.PTO]),
+  Type: z.enum([CellType.REGULAR, CellType.REGULAR_LEGACY, CellType.PTO]).transform((cellType) => cellType === CellType.REGULAR_LEGACY ? CellType.REGULAR : cellType),
   EntryID: z.string(), 
   Date: z.number(), 
   AssociateTimes: TimeEntrySchema.optional(),

--- a/src/db/schemas/UpdateTimesheet.ts
+++ b/src/db/schemas/UpdateTimesheet.ts
@@ -79,7 +79,7 @@ export type UpdateRequest = z.infer<typeof UpdateRequest>
         @AssociateId: The id of the associate whose timesheet is being submitted
 */
 export const StatusChangeRequest = z.object({
-    TimesheetId: z.string(),
+    TimesheetId: z.number(),
     AssociateId: z.string()
 })
 export type StatusChangeRequest = z.infer<typeof StatusChangeRequest>

--- a/src/db/schemas/UpdateTimesheet.ts
+++ b/src/db/schemas/UpdateTimesheet.ts
@@ -31,7 +31,7 @@ export const enum TimesheetOperations {
 */
 export const enum TimesheetListItems {
     TABLEDATA = "TABLEDATA", 
-    SCHEDULEDATA = "SCHEDULEDATA", 
+    SCHEDULEDATA = "SCHEDULEDATA", // TODO : delete this
     WEEKNOTES = "WEEKNOTES"
 }
 
@@ -73,6 +73,15 @@ export const UpdateRequest = z.object({
 })
 export type UpdateRequest = z.infer<typeof UpdateRequest>
 
+/*
+    Schema for changing the status of a timesheet 
+        @TimesheetId: The id of the timesheet we are updating 
+        @AssociateId: The id of the associate whose timesheet is being submitted
+*/
+export const StatusChangeRequest = z.object({
+    TimesheetId: z.string(),
+    AssociateId: z.string()
+})
 
 /* The main request body that is used to determine what we should be updating in a request 
     @TimesheetID: The id of the timesheet we are updating 

--- a/src/db/schemas/UpdateTimesheet.ts
+++ b/src/db/schemas/UpdateTimesheet.ts
@@ -82,7 +82,7 @@ export type UpdateRequest = z.infer<typeof UpdateRequest>
 export const StatusChangeRequest = z.object({
     TimesheetId: z.number(),
     AssociateId: z.string(),
-    authorId: z.number(),
+    authorId: z.string(),
     dateSubmitted: z.number(),
     statusType: z.enum([TimesheetStatus.FINALIZED, TimesheetStatus.HOURS_REVIEWED, TimesheetStatus.HOURS_SUBMITTED])
 })

--- a/src/db/schemas/UpdateTimesheet.ts
+++ b/src/db/schemas/UpdateTimesheet.ts
@@ -82,6 +82,7 @@ export const StatusChangeRequest = z.object({
     TimesheetId: z.string(),
     AssociateId: z.string()
 })
+export type StatusChangeRequest = z.infer<typeof StatusChangeRequest>
 
 /* The main request body that is used to determine what we should be updating in a request 
     @TimesheetID: The id of the timesheet we are updating 

--- a/src/db/schemas/UpdateTimesheet.ts
+++ b/src/db/schemas/UpdateTimesheet.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { RowSchema, CommentSchema, ScheduledRowSchema } from "../frontend/RowSchema";
 import * as dbTypes from '../schemas/Timesheet'
+import { TimesheetStatus } from "../Timesheet";
 
 /*
     The supported timesheet operations currently supported. 
@@ -80,7 +81,10 @@ export type UpdateRequest = z.infer<typeof UpdateRequest>
 */
 export const StatusChangeRequest = z.object({
     TimesheetId: z.number(),
-    AssociateId: z.string()
+    AssociateId: z.string(),
+    authorId: z.number(),
+    dateSubmitted: z.number(),
+    statusType: z.enum([TimesheetStatus.FINALIZED, TimesheetStatus.HOURS_REVIEWED, TimesheetStatus.HOURS_SUBMITTED])
 })
 export type StatusChangeRequest = z.infer<typeof StatusChangeRequest>
 

--- a/src/db/timesheets/FrontendConversions.ts
+++ b/src/db/timesheets/FrontendConversions.ts
@@ -30,7 +30,6 @@ export class DBToFrontend {
         return frontendTimesheetTypes.StatusType.parse({
             HoursSubmitted: status.HoursSubmitted, 
             HoursReviewed: status.HoursReviewed, 
-            ScheduleSubmitted: status.ScheduleSubmitted, 
             Finalized: status.Finalized
         })
     } 

--- a/src/db/timesheets/ItemsOperations.ts
+++ b/src/db/timesheets/ItemsOperations.ts
@@ -136,6 +136,9 @@ export class HoursDataOperations implements ItemsOperations {
             ...timesheet.Status,
             [body.statusType.valueOf()]: newStatusEntry
         }
+
+        console.log("Handling Status Change Request for timesheet %s", body.TimesheetId.valueOf())
+        console.log("New Status Object:\n %s", updatedStatus)
         return {
             ...timesheet, 
             Status: updatedStatus

--- a/src/db/timesheets/ItemsOperations.ts
+++ b/src/db/timesheets/ItemsOperations.ts
@@ -1,5 +1,5 @@
-import {TimeSheetSchema, TimesheetEntrySchema, ScheduleEntrySchema, NoteSchema} from '../schemas/Timesheet'
-import {UpdateRequest, InsertRequest, DeleteRequest, TimesheetListItems} from '../schemas/UpdateTimesheet'
+import {TimeSheetSchema, TimesheetEntrySchema, ScheduleEntrySchema, NoteSchema, StatusEntryType} from '../schemas/Timesheet'
+import {UpdateRequest, InsertRequest, DeleteRequest, TimesheetListItems, StatusChangeRequest} from '../schemas/UpdateTimesheet'
 import { ExceptionsHandler } from '@nestjs/core/exceptions/exceptions-handler';
 //Not sure why but only works if imported like this :| 
 const moment = require('moment-timezone'); 
@@ -14,6 +14,8 @@ interface ItemsOperations {
     Delete(timesheet: TimeSheetSchema, body:DeleteRequest): TimeSheetSchema 
     // Update a specific item in the list of items 
     Update(timesheet: TimeSheetSchema, body:UpdateRequest) : TimeSheetSchema 
+    // TODO: add a new StatusChange(....) function 
+    StatusChange(timesheet: TimeSheetSchema, body:StatusChangeRequest): TimeSheetSchema
 }
 
 /*
@@ -24,7 +26,8 @@ export class ItemsDelegator {
     // Class to determine what field of the timesheet we are performing item operations on 
     tableData = new HoursDataOperations() 
     scheduleData = new ScheduledDataOperations() 
-    notesData = new NotesOperations() 
+    notesData = new NotesOperations()
+    
 
     public AttributeToModify(body: InsertRequest | DeleteRequest | UpdateRequest) {
         switch (body.Type) {
@@ -33,7 +36,7 @@ export class ItemsDelegator {
             case TimesheetListItems.SCHEDULEDATA:
                 return this.scheduleData; 
             case TimesheetListItems.WEEKNOTES:
-                return this.notesData; 
+                return this.notesData;
             default:
                 throw new Error ("Invalid operation provided"); 
         }
@@ -46,7 +49,7 @@ export class ItemsDelegator {
     i.e. the user entered rows of the time they worked. 
 */
 export class HoursDataOperations implements ItemsOperations {
-    public  Insert(timesheet: TimeSheetSchema, body:InsertRequest)  {
+    public Insert(timesheet: TimeSheetSchema, body:InsertRequest)  {
         const data = timesheet.HoursData; 
 
         const item = TimesheetEntrySchema.parse(body.Item); 
@@ -111,6 +114,31 @@ export class HoursDataOperations implements ItemsOperations {
                 }
                 return row; 
             })
+        }
+    }
+
+    public StatusChange(timesheet: TimeSheetSchema, body:StatusChangeRequest)  {
+        if (timesheet.TimesheetID !== body.TimesheetId) {
+            throw new Error("Requested timesheet does not match timesheet ID of timesheet being updated");
+        }
+
+        /*
+        As an example...
+        original Status : {HoursSubmitted=undefined, HoursReviewed=undefined, Finalized=undefined}
+
+        StatusChangeRequest: {TimesheetId=abc, AssociateId=123456, authorId:123456, dateSubmited=0638457, StatusType='HoursSubmitted'}
+
+        new Status: {HoursSubmitted={Date: 0638457, AuthorID: 123456}, HoursReviewed=undefined, Finalized=undefined}
+        */
+
+        const newStatusEntry = {Date: body.dateSubmitted, AuthorID: body.authorId}
+        const updatedStatus = {
+            ...timesheet.Status,
+            [body.statusType.valueOf()]: newStatusEntry
+        }
+        return {
+            ...timesheet, 
+            Status: updatedStatus
         }
     }
 }
@@ -180,6 +208,10 @@ export class ScheduledDataOperations implements ItemsOperations {
             })
         }
     }
+
+    public StatusChange(timesheet: TimeSheetSchema, body:StatusChangeRequest)  {
+        return undefined;
+    }
 }
 
 // Operations on the weekly notes on the timesheet - i.e. comments relating to the entire timesheet / specific day worked. 
@@ -215,6 +247,10 @@ export class NotesOperations implements ItemsOperations {
                 return note ;
             })
         }
+    }
+
+    public StatusChange(timesheet: TimeSheetSchema, body:StatusChangeRequest)  {
+        return undefined;
     }
 }
 

--- a/src/db/timesheets/UploadTimesheet.ts
+++ b/src/db/timesheets/UploadTimesheet.ts
@@ -22,10 +22,11 @@ export class UploadTimesheet {
             userid: The user we are processing this for 
         */
         //Retrieve a specified timesheet 
+        console.log(request)
         const userTimesheets = await UserTimesheets(userid); 
         const selectedTimesheet = userTimesheets.filter((timesheet) => timesheet.TimesheetID === request.TimesheetID)
         if (selectedTimesheet.length == 1) {
-            
+            console.log("Timesheet found for Update Timesheet Operation %s", request.Operation.valueOf())
             var modifiedTimesheet = undefined; 
             switch (request.Operation) {
                 case TimesheetOperations.STATUS_CHANGE:

--- a/src/db/timesheets/UploadTimesheet.ts
+++ b/src/db/timesheets/UploadTimesheet.ts
@@ -30,7 +30,7 @@ export class UploadTimesheet {
             //TODO - Mutate the respective fields to what they should be 
             switch (request.Operation) {
                 case TimesheetOperations.STATUS_CHANGE:
-                    //TODO - Create the functionality for actually incrementing state - 
+                    //TODO - Create the functionality for actually incrementing state : This should handle the StatusCompliation object
                     break; 
                 case TimesheetOperations.DELETE: 
                     modifiedTimesheet =  this.delegator.AttributeToModify(request.Payload).Delete(selectedTimesheet[0], request.Payload); 

--- a/src/db/timesheets/UploadTimesheet.ts
+++ b/src/db/timesheets/UploadTimesheet.ts
@@ -4,7 +4,7 @@ import { TimesheetUpdateRequest, TimesheetOperations } from "../schemas/UpdateTi
 
 import {UserTimesheets} from "src/dynamodb"
 import { ExceptionsHandler } from "@nestjs/core/exceptions/exceptions-handler";
-import { ItemsDelegator } from "./ItemsOperations";
+import { HoursDataOperations, ItemsDelegator } from "./ItemsOperations";
 
 import {WriteEntryToTable} from "src/dynamodb"
 import {frontendEntryConversions} from './EntryOperations'
@@ -27,10 +27,10 @@ export class UploadTimesheet {
         if (selectedTimesheet.length == 1) {
             
             var modifiedTimesheet = undefined; 
-            //TODO - Mutate the respective fields to what they should be 
             switch (request.Operation) {
                 case TimesheetOperations.STATUS_CHANGE:
-                    //TODO - Create the functionality for actually incrementing state : This should handle the StatusCompliation object
+                    // This operation should only be supported for Hours Data
+                    modifiedTimesheet = this.delegator.tableData.StatusChange(selectedTimesheet[0], request.Payload);
                     break; 
                 case TimesheetOperations.DELETE: 
                     modifiedTimesheet =  this.delegator.AttributeToModify(request.Payload).Delete(selectedTimesheet[0], request.Payload); 
@@ -50,7 +50,7 @@ export class UploadTimesheet {
                     throw new Error(`Invalid operation: ${request.Operation}`); 
             }
             if (modifiedTimesheet !== undefined) {
-                WriteEntryToTable(modifiedTimesheet); 
+                WriteEntryToTable(modifiedTimesheet);
                 return "Success :)"
             }
             return "Failure"; 

--- a/src/utils/mock/user.mock.ts
+++ b/src/utils/mock/user.mock.ts
@@ -13,5 +13,5 @@ export const mockSupervisor: User = {
   given_name: "Test",
   family_name: "Admin",
   phone_number: "+11234567890",
-  "cognito:groups": ["breaktime-supervisor"],
+  "cognito:groups": ["breaktime-supervisor", "breaktime-associate"],
 };

--- a/test/UploadTimesheet.ts
+++ b/test/UploadTimesheet.ts
@@ -11,7 +11,7 @@ Utils file used in testing to upload entire timesheets
 
 
 const TIMEZONE = "America/New_York"; 
-const UUID = "77566d69-3b61-452a-afe8-73dcda96f876"
+const UUID = "4c8c5ad4-a8ab-4c92-b33f-b8f932b9e0b5"
 
 function createTimeEntry(start, end) {
     return TimeEntrySchema.parse({


### PR DESCRIPTION
ℹ️ Issue : Helps close frontend #61

📝 Description:
Added in full support for the StatusChange operation request.


✔️ Testing
Added new POST requests to Postman collection and tested the backend with those.
To replicate, run the [Status Change: Hours Submitted (Assoc)](https://warped-station-270942.postman.co/workspace/Breaktime~91d9d6cd-56aa-4bda-aff6-86f8cbb7f8bc/request/25120816-99b6abc3-b751-49bd-bcfd-48393334b2f4) request, editing the TimesheetID and AssociateId as needed. Then, run the [Get Timesheet](https://warped-station-270942.postman.co/workspace/Breaktime~91d9d6cd-56aa-4bda-aff6-86f8cbb7f8bc/request/25120816-70cb776e-ee86-47c6-9882-16129f73910f) request for that user to ensure that the Status object was updated accordingly.

For example, the request:
`{
    "TimesheetID": 593683817,
    "Operation": "STATUS_CHANGE",
    "Payload": {
        "TimesheetId": 593683817,
        "AssociateId": "4c8c5ad4-a8ab-4c92-b33f-b8f932b9e0b5",
        "authorId": "4c8c5ad4-a8ab-4c92-b33f-b8f932b9e0b5",
        "dateSubmitted": 1699815250,
        "statusType": "HoursSubmitted"
    }
}`

results in updating the timesheet like:

`    {
        "TimesheetID": 593683817,
        "UserID": "4c8c5ad4-a8ab-4c92-b33f-b8f932b9e0b5",
        "StartDate": 1699765200,
        "Status": {
            "HoursSubmitted": {
                "Date": 1699815250,
                "AuthorID": "4c8c5ad4-a8ab-4c92-b33f-b8f932b9e0b5"
            }
       }
....`

Also fixed a bug with the `ENV_TYPE=testing` option, where the incorrect user sub value was being used for the mock authentication.
