### PR TITLE
Adding in getUsersByIds, and adding in user roles to return data

### DIFF
--- a/src/aws/auth.service.ts
+++ b/src/aws/auth.service.ts
@@ -16,12 +16,12 @@ export class AuthService {
    * @param jwt The access token to be validated
    * @returns if the validation was successful and what Cognito groups the user is a part of
    */
-  async verifyJwt(jwt: string): Promise<AuthVerificationResponse> {
+  async verifyJwt(jwt: string): Promise<ValidatedUser> {
     if (process.env.ENV_TYPE && process.env.ENV_TYPE === "test") {
       console.log(
         "Testing environment - mock user will be used, authentication skipped"
       );
-      return { isValidated: true, groups: mockSupervisor["cognito:groups"] };
+      return { isValidated: true, groups: mockSupervisor["cognito:groups"], sub: mockSupervisor.sub };
     }
     try {
       const userPayload = await this.cognitoService.validate(jwt);
@@ -30,14 +30,18 @@ export class AuthService {
       // This is so that the role-based access is determined by Cognito groups
       const groups = userPayload["cognito:groups"];
 
-      return { isValidated: true, groups: groups };
+      return { isValidated: true, groups: groups, sub: userPayload.sub };
     } catch (e) {
       throw new UnauthorizedException();
     }
   }
 }
 
-export type AuthVerificationResponse = {
+/**
+ * Represents the user data from the Cognito token validation process
+ */
+export type ValidatedUser = {
   isValidated: boolean;
   groups: string[];
+  sub: string;
 };

--- a/src/aws/cognito/Roles.ts
+++ b/src/aws/cognito/Roles.ts
@@ -1,0 +1,5 @@
+export enum CognitoRoles {
+  ADMIN = 'breaktime-admin',
+  SUPERVISOR = 'breaktime-supervisor',
+  ASSOCIATE = 'breaktime-associate'
+}

--- a/src/aws/cognito/cognito.service.ts
+++ b/src/aws/cognito/cognito.service.ts
@@ -11,7 +11,19 @@ export class CognitoService {
     return await this.cognitoWrapper.validate(jwt);
   }
 
-  async getUsers(userIDs: string[]) {
+  /**
+   * Gets a list of users from Cognito user pool. If no user ids are provided, will return
+   * all users by default.
+   *
+   * @param userIDs optional list of user ids to search for
+   * @param roles optional list of roles to search for
+   * @returns
+   */
+  async getUsers(userIDs?: string[], roles?: string[]) {
+    if (!userIDs) {
+      return await this.cognitoWrapper.getUsers();
+    }
+
     return await this.cognitoWrapper.getUsersByIds(userIDs);
   }
 }

--- a/src/aws/cognito/cognito.wrapper.ts
+++ b/src/aws/cognito/cognito.wrapper.ts
@@ -67,6 +67,8 @@ export class CognitoWrapper {
         throw new Error("Issue with retrieving user data from user pool.");
       }
 
+      userData.forEach((user) => console.log(user.Attributes))
+
       return userData
         .filter((user) =>
           userIDs.includes(

--- a/src/aws/cognito/cognito.wrapper.ts
+++ b/src/aws/cognito/cognito.wrapper.ts
@@ -65,11 +65,9 @@ export class CognitoWrapper {
           parsedUser.Attributes.push({Name: "cognito:groups", Value: role});
           return parsedUser;
         })
-        console.log("MODIFIED USERS FOR %s", role)
         userData = [...userData, ...modifiedUsers]
       }
 
-      console.log(userData);
       return userData;
     } catch (error) {
       console.log(error);

--- a/src/aws/cognito/cognito.wrapper.ts
+++ b/src/aws/cognito/cognito.wrapper.ts
@@ -68,7 +68,11 @@ export class CognitoWrapper {
       }
 
       return userData
-        .filter((user) => userIDs.includes(user.Attributes["sub"]))
+        .filter((user) =>
+          userIDs.includes(
+            user.Attributes.find((attribute) => (attribute.Name = "sub")).Value
+          )
+        )
         .map((user) => CognitoUser.parse(user));
     } catch (error) {
       console.log(error);

--- a/src/aws/decorators/roles.decorators.ts
+++ b/src/aws/decorators/roles.decorators.ts
@@ -1,6 +1,0 @@
-import { SetMetadata } from "@nestjs/common";
-
-/**
- * A custom decorator that allows us to take in a set of groups or roles and process them in the Nest pipeline (i.e. RolesGuard).
- */
-export const Roles = (...roles: string[]) => SetMetadata("roles", roles);

--- a/src/aws/guards/roles.guard.ts
+++ b/src/aws/guards/roles.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
-import { AuthVerificationResponse } from "../auth.service";
+import { ValidatedUser } from "../auth.service";
 
 /**
  * Nest guard for role-based access (i.e. groups from Cognito). Reference: https://docs.nestjs.com/guards
@@ -32,7 +32,7 @@ export class RolesGuard implements CanActivate {
     // this is what has been set by the previous step(s).
     // In our case, this is from the Cognito groups a user is assigned.
     const request = context.switchToHttp().getRequest();
-    const user: AuthVerificationResponse = request.user;
+    const user: ValidatedUser = request.user;
 
     // Check that the user belongs to at least one of the required roles
     const validUserGroups = user.groups.filter((group) =>

--- a/src/aws/middleware/authentication.middleware.ts
+++ b/src/aws/middleware/authentication.middleware.ts
@@ -16,6 +16,7 @@ export class AuthenticationMiddleware implements NestMiddleware {
       req.user = {
         isValidated: true,
         groups: mockSupervisor["cognito:groups"],
+        sub: mockSupervisor.sub
       };
       return next();
     }

--- a/src/users/User.model.ts
+++ b/src/users/User.model.ts
@@ -10,6 +10,7 @@ export type UserModel = {
   userEmail: string;
   associateCompanyIds?: string[];
   supervisorCompanyIds?: string[];
+  userRole: string;
 };
 
 // alt

--- a/src/users/User.model.ts
+++ b/src/users/User.model.ts
@@ -8,6 +8,8 @@ export type UserModel = {
   lastName: string;
   userID: string;
   userEmail: string;
+  associateCompanyIds?: string[];
+  supervisorCompanyIds?: string[];
 };
 
 // alt

--- a/src/users/User.model.ts
+++ b/src/users/User.model.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 /**
  * Represents the model schema of a User
  */
-export type User = {
+export type UserModel = {
   firstName: string;
   lastName: string;
   userID: string;

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -8,6 +8,7 @@ import { GetCompaniesForUser, GetCompanyData } from "src/dynamodb";
 import { CognitoRoles } from "src/aws/cognito/Roles";
 import { error } from "console";
 
+// TODO : create a custom filter class instead of this that for each user
 @Injectable()
 export class UserService {
   constructor(private cognitoService: CognitoService) {}

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -292,7 +292,9 @@ export class UserService {
     var lastName = user.Attributes.find(
       (attribute) => attribute.Name === "family_name"
     );
-
+    var group = user.Attributes.find(
+      (attribute) => attribute.Name === "cognito:groups"
+    )
     // TODO : refactor into separate 'getAttribute' function so we don't repeat this code
 
     return {
@@ -300,6 +302,7 @@ export class UserService {
       lastName: lastName != null ? lastName.Value : "",
       userEmail: email != null ? email.Value : "",
       userID: sub.Value,
+      userRole: group != null ? group.Value : "",
     };
   }
 }

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -1,30 +1,183 @@
-import { Injectable } from "@nestjs/common";
+import { HttpException, HttpStatus, Injectable } from "@nestjs/common";
 import { CognitoUser } from "src/aws/cognito/User.client";
 import { CognitoService } from "src/aws/cognito/cognito.service";
-import { User } from "./User.model";
-import { last } from "rxjs";
+import { UserModel } from "./User.model";
+import { combineAll, last } from "rxjs";
+import { ValidatedUser } from "src/aws/auth.service";
+import { GetCompaniesForUser, GetCompanyData } from "src/dynamodb";
+import { CognitoRoles } from "src/aws/cognito/Roles";
+import { error } from "console";
 
 @Injectable()
 export class UserService {
   constructor(private cognitoService: CognitoService) {}
 
-  async getUsersFromCognito(userIDs: string[]): Promise<User[]> {
-    try {
-      const users = await this.cognitoService.getUsers(userIDs);
+  async getUsers(
+    user: ValidatedUser,
+    companyIds: string[],
+    searchRoles: string[]
+  ): Promise<CompanyUsers[]> {
+    const companyUserList: CompanyUsers[] = [];
 
-      // Parse out user data, map to the correct object here?
-      for (const user of users) {
-        console.log(user.Attributes);
+    const userSearch = AUserSearch.createUserSearch(
+      searchRoles,
+      companyIds,
+      user
+    );
+
+    userSearch.VerifyCompanies();
+    userSearch.GetUsers();
+
+    // Determine what primary role should be used when searching, i.e. what permissions should take precedence
+    let primaryUserRole: CognitoRoles;
+    if (user.groups.includes(CognitoRoles.ADMIN)) {
+      primaryUserRole = CognitoRoles.ADMIN;
+    } else if (user.groups.includes(CognitoRoles.SUPERVISOR)) {
+      primaryUserRole = CognitoRoles.SUPERVISOR;
+    } else if (user.groups.includes(CognitoRoles.ASSOCIATE)) {
+      primaryUserRole = CognitoRoles.ASSOCIATE;
+    } else {
+      throw new HttpException(
+        "No valid groups found for user",
+        HttpStatus.UNAUTHORIZED
+      );
+    }
+
+    // Determine companies to search for
+    /*
+    associates: should be able to get data for supervisors in their company and admins, but no one else
+    supervisors: should be able to get data for admins and all users in their company
+    admins: unrestricted
+    */
+    if (primaryUserRole != CognitoRoles.ADMIN) {
+      if (companyIds === undefined || companyIds.length === 0) {
+        if (primaryUserRole === CognitoRoles.SUPERVISOR) {
+          companyIds = (await GetCompaniesForUser(user.sub))
+            .SupervisorCompanyIDs;
+        } else if (primaryUserRole === CognitoRoles.ASSOCIATE) {
+          companyIds = (await GetCompaniesForUser(user.sub))
+            .AssociateCompanyIDs;
+        }
+      } else {
+        this.verifyAllowedCompanies(companyIds, user);
       }
+    }
 
-      return users.map((user) => UserService.convertClientToModelUser(user));
+    // get all users associated with companyId(s)
+    // If admin and companyIds is empty, get everything
+
+    for (const companyId of companyIds) {
+      const companyUserData = await this.getCompanyUserData(
+        companyId,
+        searchRoles
+      );
+      companyUserList.push(companyUserData);
+    }
+
+    // If admin data is requested
+    if (searchRoles.includes("admin")) {
+      
+    }
+
+    // return company array
+    return companyUserList;
+  }
+
+  /**
+   * TODO
+   * @returns
+   */
+  async getAllUsersFromCognito(): Promise<UserModel[]> {
+    const users = await this.cognitoService.getUsers();
+    return users.map((user) => UserService.convertClientToModelUser(user));
+  }
+
+  /**
+   * TODO
+   * @param userIDs
+   * @returns
+   */
+  async getUsersFromCognito(userIds: string[]): Promise<UserModel[]> {
+    try {
+      // TODO: this filtering might be better in the cognito service class, depending on if we expect to use the functionality elsewhere
+      const users = await this.cognitoService.getUsers();
+      return users
+        .filter((user) => userIds.includes(user.Attributes["sub"]))
+        .map((user) => UserService.convertClientToModelUser(user));
     } catch (err) {
       console.log(err);
       return [];
     }
   }
 
-  static convertClientToModelUser(user: CognitoUser): User {
+  /**
+   * TODO
+   * @param companyId
+   * @param searchRoles
+   * @returns
+   */
+  async getCompanyUserData(
+    companyId: string,
+    searchRoles: string[]
+  ): Promise<CompanyUsers> {
+    // This will be db call with companyIds as a filter on the query
+    // This only gets the UserIDs, NOT all the user info
+    const companyData = await GetCompanyData(companyId);
+
+    let associateData = [];
+    let supervisorData = [];
+    let companyUserData: CompanyUsers = { CompanyID: companyId };
+
+    if (searchRoles.includes("associate")) {
+      associateData = await this.getUsersFromCognito(companyData.AssociateIDs);
+      companyUserData.Associates = associateData;
+    }
+
+    if (searchRoles.includes("supervisor")) {
+      supervisorData = await this.getUsersFromCognito(
+        companyData.SupervisorIDs
+      );
+      companyUserData.Supervisors = supervisorData;
+    }
+    return companyUserData;
+  }
+
+  /**
+   * TODO
+   * @param companyIds
+   * @param user
+   * @returns
+   */
+  private async verifyAllowedCompanies(
+    companyIds: string[],
+    user: ValidatedUser
+  ) {
+    // Admins have access to all companies
+    if (user.groups.includes(CognitoRoles.ADMIN)) {
+      return;
+    }
+
+    const allowedCompanies = user.groups.includes(CognitoRoles.SUPERVISOR)
+      ? (await GetCompaniesForUser(user.sub)).SupervisorCompanyIDs
+      : (await GetCompaniesForUser(user.sub)).AssociateCompanyIDs;
+
+    // Throw an error if the user is not an admin and doesn't have access to one or more of the companyIDs specified
+    for (const companyId of companyIds) {
+      if (!allowedCompanies.includes(companyId)) {
+        throw new HttpException(
+          `User is not authorized to access company data for company ID ${companyId}`,
+          HttpStatus.UNAUTHORIZED
+        );
+      }
+    }
+  }
+
+  /**
+   * TODO
+   * @param user
+   * @returns
+   */
+  static convertClientToModelUser(user: CognitoUser): UserModel {
     var sub = user.Attributes.find((attribute) => attribute.Name === "sub");
     var email = user.Attributes.find((attribute) => attribute.Name === "email");
     var firstName = user.Attributes.find(
@@ -42,5 +195,111 @@ export class UserService {
       userEmail: email != null ? email.Value : "",
       userID: sub.Value,
     };
+  }
+}
+
+export type CompanyUsers = {
+  CompanyID: string;
+  Associates?: UserModel[];
+  Supervisors?: UserModel[];
+};
+
+// TODO: come up with a better name for this, maybe something like ScopedUserSearch
+// This is a functional class that represents the different ways to process getting users
+// for different roles (admin, supervisor, or associate)
+abstract class AUserSearch {
+  private _searchUserIds: string[];
+  private _searchCompanyIds: string[];
+  private _user: ValidatedUser;
+
+  constructor(
+    private searchUserIds: string[],
+    private searchCompanyIds: string[],
+    private user: ValidatedUser
+  ) {
+    this._searchUserIds = searchUserIds;
+    this._searchCompanyIds = searchCompanyIds;
+    this._user = user;
+  }
+
+  abstract UserDtoMapper(user: CognitoUser): UserModel;
+  abstract VerifyCompanies();
+  abstract GetUsers();
+
+  // factory method to create the correct type of processing user
+  static createUserSearch(
+    searchUserIds: string[],
+    searchCompanyIds: string[],
+    user: ValidatedUser
+  ): AUserSearch {
+    if (user.groups.includes(CognitoRoles.ADMIN)) {
+      return new AdminProcessingUser(searchUserIds, searchCompanyIds, user);
+    } else if (user.groups.includes(CognitoRoles.SUPERVISOR)) {
+      return new SupervisorProcessingUser(
+        searchUserIds,
+        searchCompanyIds,
+        user
+      );
+    } else if (user.groups.includes(CognitoRoles.ASSOCIATE)) {
+      return new AssociateProcessingUser(searchUserIds, searchCompanyIds, user);
+    }
+    throw error("No valid groups found for user.");
+  }
+}
+
+class AdminProcessingUser extends AUserSearch {
+  UserDtoMapper(user: {
+    Attributes?: { Name?: string; Value?: string }[];
+    Enabled?: boolean;
+    UserCreateDate?: Date;
+    UserLastModifiedDate?: Date;
+    UserStatus?: string;
+    Username?: string;
+  }): UserModel {
+    throw new Error("Method not implemented.");
+  }
+  VerifyCompanies() {
+    throw new Error("Method not implemented.");
+  }
+  GetUsers() {
+    throw new Error("Method not implemented.");
+  }
+}
+
+class SupervisorProcessingUser extends AUserSearch {
+  UserDtoMapper(user: {
+    Attributes?: { Name?: string; Value?: string }[];
+    Enabled?: boolean;
+    UserCreateDate?: Date;
+    UserLastModifiedDate?: Date;
+    UserStatus?: string;
+    Username?: string;
+  }): UserModel {
+    throw new Error("Method not implemented.");
+  }
+  VerifyCompanies() {
+    throw new Error("Method not implemented.");
+  }
+  GetUsers() {
+    throw new Error("Method not implemented.");
+  }
+}
+
+class AssociateProcessingUser extends AUserSearch {
+  UserDtoMapper(user: {
+    Attributes?: { Name?: string; Value?: string }[];
+    Enabled?: boolean;
+    UserCreateDate?: Date;
+    UserLastModifiedDate?: Date;
+    UserStatus?: string;
+    Username?: string;
+  }): UserModel {
+    throw new Error("Method not implemented.");
+  }
+  VerifyCompanies() {
+    throw new Error("Method not implemented.");
+  }
+  GetUsers() {
+    throw new Error("Method not implemented.");
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -40,12 +40,16 @@ export class UsersController {
     @Headers() headers: any,
     @User() user: ValidatedUser,
     @Query("companyIds") companyIds?: string[],
-    @Query("roles") roles: string[] = ["associate"]
+    @Query("roles") roles: string[] = ["associate"],
+    @Query("userIds") userIds: string[] = []
   ): Promise<CompanyUsers[]> {
     if (!user.sub) {
-      throw new HttpException('No authorized user found', HttpStatus.UNAUTHORIZED);
+      throw new HttpException(
+        "No authorized user found",
+        HttpStatus.UNAUTHORIZED
+      );
     }
 
-    return this.userService.getUsers(user, companyIds ?? [], roles);
+    return this.userService.getUsers(user, companyIds ?? [], roles, userIds);
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -24,7 +24,7 @@ import { CognitoRoles } from "src/aws/cognito/Roles";
 export class UsersController {
   constructor(private userService: UserService) {}
 
-  // TODO : For now, this primarily just works for supervisors, rather than admins. Some additional checks will need to be added for full admin support
+  // TODO: Ultimately, this should likely be reworked into a separate 'company' endpoint
   /**
    * Gets all the user data from a certain company/companies and returns and array. If no company ID is given,
    * we'll default to use the companies that the requesting user belongs to as the filter. If the user is an admin, return all users
@@ -35,8 +35,8 @@ export class UsersController {
    * @throws 401 UNAUTHORIZED if the companyID requested is not one that the user has access to
    * @returns an array of Company objects that contain the companyID and associated User data
    */
-  @Get("users")
-  public async getUsers(
+  @Get("usersCompanies")
+  public async getUsersAndCompanies(
     @Headers() headers: any,
     @User() user: ValidatedUser,
     @Query("companyIds") companyIds?: string[],
@@ -50,7 +50,41 @@ export class UsersController {
       );
     }
 
-    return this.userService.getUsers(user, companyIds ?? [], roles, userIds);
+    //return this.userService.getUsers(user, companyIds ?? [], roles, userIds);
+    throw new Error("Not implemented.")
+  }  
+
+  @Get("userById")
+  public async getUserById(
+    @Headers() headers: any,
+    @User() requester: ValidatedUser,
+    @Query("userIds") userIds: string[] = []
+  ): Promise<UserModel> {
+    if (!requester.sub) {
+      throw new HttpException(
+        "No authorized user found",
+        HttpStatus.UNAUTHORIZED
+      );
+    }
+    
+    // TODO: Throw error if no users found
+    return this.userService.getUsersByIds(requester, userIds)[0];
+  }
+
+  @Roles("breaktime-admin")
+  @Get("allUsers")
+  public async getAllUsers(
+    @Headers() headers: any,
+    @User() requester: ValidatedUser
+  ): Promise<UserModel[]> {
+    if (!requester.sub) {
+      throw new HttpException(
+        "No authorized user found",
+        HttpStatus.UNAUTHORIZED
+      );
+    }
+
+    return this.userService.getAllUsers()
   }
 
   @Get("usersById")

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -52,4 +52,20 @@ export class UsersController {
 
     return this.userService.getUsers(user, companyIds ?? [], roles, userIds);
   }
+
+  @Get("usersById")
+  public async getUsersByIds(
+    @Headers() headers: any,
+    @User() requester: ValidatedUser,
+    @Query("userIds") userIds: string[] = []
+  ): Promise<UserModel[]> {
+    if (!requester.sub) {
+      throw new HttpException(
+        "No authorized user found",
+        HttpStatus.UNAUTHORIZED
+      );
+    }
+
+    return this.userService.getUsersByIds(requester, userIds);
+  }
 }

--- a/src/utils/decorators/user.decorator.ts
+++ b/src/utils/decorators/user.decorator.ts
@@ -1,0 +1,11 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+/**
+ * Creates a custom decorator that returns the request's user data based on the NestJS pipeline (e.g. authorization, roles guard, etc.)
+ */
+export const User = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/src/utils/guards/roles.guard.ts
+++ b/src/utils/guards/roles.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable, CanActivate, ExecutionContext } from "@nestjs/common";
 import { Reflector } from "@nestjs/core";
-import { AuthVerificationResponse } from "src/aws/auth.service";
+import { ValidatedUser } from "src/aws/auth.service";
 
 /**
  * Nest guard for role-based access (i.e. groups from Cognito). Reference: https://docs.nestjs.com/guards
@@ -32,7 +32,7 @@ export class RolesGuard implements CanActivate {
     // this is what has been set by the previous step(s).
     // In our case, this is from the Cognito groups a user is assigned.
     const request = context.switchToHttp().getRequest();
-    const user: AuthVerificationResponse = request.user;
+    const user: ValidatedUser = request.user;
 
     // Check that the user belongs to at least one of the required roles
     const validUserGroups = user.groups.filter((group) =>


### PR DESCRIPTION
ℹ️ Issue #48 

📝 Description 
Added a bunch of code for the UserService file to start supporting different user permissions for the getUsers and getUsersByIds endpoints. _Note: there is quite a bit of unused code in the `userService.ts` file - some of it might need to get cleaned up in the future or fully fleshed out_

Switched how we are getting user data from Cognito, from the ListUsers command to ListUsersInGroups command in order to also pull down user role data.

Added in a `User` decorator to be used for Nest controller methods, so we can easily get requester user data like sub and role without having to recall the `TokenClient.verifyJwt` method every time.

✔️ Testing What steps did you take to verify your changes work?
Testing with the following PostMan requests:

-[ Get Users By Id](https://warped-station-270942.postman.co/workspace/Breaktime~91d9d6cd-56aa-4bda-aff6-86f8cbb7f8bc/request/25120816-0e18d7b7-80a5-4a43-b2c3-3e3859c3719d)
- [Get Users](https://warped-station-270942.postman.co/workspace/Breaktime~91d9d6cd-56aa-4bda-aff6-86f8cbb7f8bc/request/25120816-f38f094d-1b8e-4220-9b8d-a5cd705d51db)


🏕️ (Optional) Future Work / Notes 
Like half of the code for the `userService.ts` file need to get updated, but oh well.